### PR TITLE
fix: database is not encrypted

### DIFF
--- a/example/ios/OPSQLiteExample.xcodeproj/project.pbxproj
+++ b/example/ios/OPSQLiteExample.xcodeproj/project.pbxproj
@@ -402,11 +402,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -476,11 +472,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -16,9 +16,11 @@ PODS:
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
   - op-sqlcipher (1.0.8):
+    - OpenSSL-Universal
     - React
     - React-callinvoker
     - React-Core
+  - OpenSSL-Universal (1.1.2200)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -493,6 +495,7 @@ SPEC REPOS:
   trunk:
     - fmt
     - libevent
+    - OpenSSL-Universal
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -593,7 +596,8 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  op-sqlcipher: c5c860b43e41067ba1362e092d9483d4f269bd2d
+  op-sqlcipher: 91ea8b416133e1f5eaf148e5b4b221d82a9169f9
+  OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29

--- a/example/src/Database.ts
+++ b/example/src/Database.ts
@@ -7,13 +7,15 @@ const chance = new Chance();
 
 const ROWS = 300000;
 const DB_NAME = 'largeDB';
+const ENCRYPTION_KEY = 'quack';
+const DB_CONFIG = {
+  name: DB_NAME,
+  // inMemory: true,
+  encryptionKey: ENCRYPTION_KEY,
+};
 
 export async function createLargeDB() {
-  let largeDb = open({
-    name: DB_NAME,
-    // inMemory: true,
-    encryptionKey: 'quack',
-  });
+  let largeDb = open(DB_CONFIG);
 
   largeDb.execute('DROP TABLE IF EXISTS Test;');
   largeDb.execute(
@@ -52,9 +54,7 @@ export async function createLargeDB() {
 }
 
 export async function queryLargeDB() {
-  let largeDb = open({
-    name: DB_NAME,
-  });
+  let largeDb = open(DB_CONFIG);
 
   let times: {loadFromDb: number[]; access: number[]} = {
     loadFromDb: [],

--- a/op-sqlcipher.podspec
+++ b/op-sqlcipher.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/op-engineering/op-sqlcipher.git", :tag => "#{s.version}" }
 
   s.pod_target_xcconfig = {
-    :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1",
+    :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1 SQLITE_HAS_CODEC SQLITE_TEMP_STORE=2",
     :WARNING_CFLAGS => "-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized -Wno-deprecated-declarations",
     :USE_HEADERMAP => "No"
   }
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.dependency "React-callinvoker"
   s.dependency "React"
   s.dependency "React-Core"
+  s.dependency "OpenSSL-Universal"
 
   s.xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',


### PR DESCRIPTION
Current version of `op-sqlcipher` is not encrypted at all (if you open file in plain text editor you can see data). 

This is only draft as I am in the middle of investigation why it doesn't work, also I am testing this only on iOS for now.

What I found so far:
1. ~~There needs to be some flags during compiling process so I added them https://github.com/sqlcipher/sqlcipher#compiling~~ - Not needed, output is same anyway according to git diff
2. I added OpenSSL which is needed to handle encryption
3. I added these flags to podspec `GCC_PREPROCESSOR_DEFINITIONS` otherwise Cipher part is not compiled into final app and key is ignored

DB file seems to be encrypted now 🎉 

I will continue to report here as I move on with debugging.